### PR TITLE
Changed closures property data type to string

### DIFF
--- a/src/models/location.model.js
+++ b/src/models/location.model.js
@@ -14,12 +14,8 @@ const LocationSchema = new Schema({
   postalCode: String,
   locationProvince: String,
   hours: String,
-  closures: [
-    {
-      periodStart: Date,
-      periodEnd: Date
-    }
-  ],
+  defaultClosures: String,
+  customClosures: String,
   bioKitAmount: Number,
   bioKits: {
     type: [BioKitSchema],


### PR DESCRIPTION
This is to better work with the front end that is already designed to receive closure information as a single string of comma delimited days.