### PR TITLE
dateConfirmed property is always null on temp appointments

### DIFF
--- a/src/routes/appointments.routes.js
+++ b/src/routes/appointments.routes.js
@@ -169,6 +169,7 @@ router.post('/appointments/temp', (req, res) => {
   model.maintenance = false;
   model.cancelledByClient = false;
   model.cancelledByLocation = false;
+  model.dateConfirmed = null;
   model.expires = moment()
     .add(5, 'minutes')
     .toDate();


### PR DESCRIPTION
When a new temporary appointment is created, dateConfirmed property will always be set to null by the server before saving the document.