### PR TITLE
Added privateAccessible property to Appointments model

### DIFF
--- a/Tools/dataSeeder/DataSeeder.js
+++ b/Tools/dataSeeder/DataSeeder.js
@@ -86,6 +86,8 @@ const populateDatabase = async () => {
         expires: null,
         // Every 20 appointments are maintenance appointments
         maintenance: !(i % 20),
+        // Every 10 appointments are accessible/private
+        privateAccessible: !(i % 10),
         // Every 10 appointments are flagged as cancelled by the client
         cancelledByClient: !(i % 10),
         // Every 19 appointments are flagged as cancelled by the location/site

--- a/src/models/appointments.model.js
+++ b/src/models/appointments.model.js
@@ -10,6 +10,7 @@ const AppointmentSchema = new Schema({
   dateConfirmed: Date,
   expires: Date,
   maintenance: Boolean,
+  privateAccessible: Boolean,
   cancelledByClient: Boolean,
   cancelledByLocation: Boolean
 });


### PR DESCRIPTION
Indicates whether an appointment was created as accessible and/or private. According to the client, accessible and private appointments are considered the same and will depend on the same BioKits.